### PR TITLE
Added settings to the Map Window

### DIFF
--- a/pla_reverse_gui/settings_dialog.py
+++ b/pla_reverse_gui/settings_dialog.py
@@ -165,19 +165,20 @@ class SettingsDialog(QDialog):
 
     def update_change_all_combo(self):
         """Add or remove 'Base Research' from the change-all dropdown based on charm state."""
-        current_index = self.change_all_combo.currentIndex()
+        self.change_all_combo.blockSignals(True)   # <-- prevent signal emission
         current_text = self.change_all_combo.currentText()
         self.change_all_combo.clear()
         if self.charm_check.isChecked():
             self.change_all_combo.addItems(["Research Level 10", "Perfect Research"])
         else:
             self.change_all_combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
-        # Try to restore the previous selection if possible
+        # Try to restore previous selection if possible
         index = self.change_all_combo.findText(current_text)
         if index >= 0:
             self.change_all_combo.setCurrentIndex(index)
         else:
             self.change_all_combo.setCurrentIndex(0)
+        self.change_all_combo.blockSignals(False)
 
     def change_all_research_level(self, index):
         """Set all species combos to the selected research level."""

--- a/pla_reverse_gui/settings_dialog.py
+++ b/pla_reverse_gui/settings_dialog.py
@@ -28,23 +28,6 @@ class SettingsDialog(QDialog):
         # Main layout
         layout = QVBoxLayout(self)
 
-        # Top row: Shiny charm + "Change all to"
-        top_row = QHBoxLayout()
-        self.charm_check = QCheckBox("Shiny Charm")
-        self.charm_check.setChecked(self.shiny_charm)
-        self.charm_check.toggled.connect(self.on_charm_toggled)
-        top_row.addWidget(self.charm_check)
-
-        top_row.addStretch()
-
-        top_row.addWidget(QLabel("Change all to:"))
-        self.change_all_combo = QComboBox()
-        self.change_all_combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
-        self.change_all_combo.currentIndexChanged.connect(self.change_all_research_level)
-        top_row.addWidget(self.change_all_combo)
-
-        layout.addLayout(top_row)
-
         # Shiny search checkbox
         self.shiny_search_check = QCheckBox("Always search for shiny Pokemon")
         self.shiny_search_check.setChecked(self.always_shiny)
@@ -88,6 +71,23 @@ class SettingsDialog(QDialog):
         self.alpha_search_check = QCheckBox("Always search for alpha Pokemon")
         self.alpha_search_check.setChecked(self.always_alpha)
         layout.addWidget(self.alpha_search_check)
+        
+        # Bottom row: Shiny charm + "Change all to"
+        bottom_row = QHBoxLayout()
+        self.charm_check = QCheckBox("Shiny Charm")
+        self.charm_check.setChecked(self.shiny_charm)
+        self.charm_check.toggled.connect(self.on_charm_toggled)
+        bottom_row.addWidget(self.charm_check)
+
+        bottom_row.addStretch()
+
+        bottom_row.addWidget(QLabel("Change all to:"))
+        self.change_all_combo = QComboBox()
+        self.change_all_combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
+        self.change_all_combo.currentIndexChanged.connect(self.change_all_research_level)
+        bottom_row.addWidget(self.change_all_combo)
+
+        layout.addLayout(bottom_row)
 
         # Table for species research levels
         self.table = QTableWidget()

--- a/pla_reverse_gui/settings_dialog.py
+++ b/pla_reverse_gui/settings_dialog.py
@@ -1,0 +1,225 @@
+"""Preferences dialog for default research levels and other search preferences"""
+
+import numpy as np
+
+from qtpy.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QCheckBox,
+    QTableWidget, QTableWidgetItem, QComboBox, QHeaderView,
+    QPushButton, QAbstractItemView, QWidget, QLabel,
+    QRadioButton, QButtonGroup
+)
+from qtpy.QtCore import QSettings, Qt
+from .util import get_name_en
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+        self.setMinimumSize(500, 600)  # Increased width a bit
+
+        # Load settings
+        self.settings = QSettings("PLAReverseGUI", "Settings")
+        self.shiny_charm = self.settings.value("shinyCharm", False, bool)
+        self.always_shiny = self.settings.value("alwaysSearchShiny", False, bool)
+        self.shiny_type = self.settings.value("shinyType", 2, int)  # 0=Star,1=Square,2=Any
+        self.always_alpha = self.settings.value("alwaysSearchAlpha", False, bool)
+
+        # Main layout
+        layout = QVBoxLayout(self)
+
+        # Top row: Shiny charm + "Change all to"
+        top_row = QHBoxLayout()
+        self.charm_check = QCheckBox("Shiny Charm")
+        self.charm_check.setChecked(self.shiny_charm)
+        self.charm_check.toggled.connect(self.on_charm_toggled)
+        top_row.addWidget(self.charm_check)
+
+        top_row.addStretch()
+
+        top_row.addWidget(QLabel("Change all to:"))
+        self.change_all_combo = QComboBox()
+        self.change_all_combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
+        self.change_all_combo.currentIndexChanged.connect(self.change_all_research_level)
+        top_row.addWidget(self.change_all_combo)
+
+        layout.addLayout(top_row)
+
+        # Shiny search checkbox
+        self.shiny_search_check = QCheckBox("Always search for shiny Pokemon")
+        self.shiny_search_check.setChecked(self.always_shiny)
+        self.shiny_search_check.toggled.connect(self.on_shiny_search_toggled)
+        layout.addWidget(self.shiny_search_check)
+
+        # Shiny type options (indented)
+        shiny_type_widget = QWidget()
+        shiny_type_layout = QHBoxLayout(shiny_type_widget)
+        shiny_type_layout.setContentsMargins(20, 0, 0, 0)  # indent
+
+        self.shiny_star_radio = QRadioButton("Star")
+        self.shiny_square_radio = QRadioButton("Square")
+        self.shiny_any_radio = QRadioButton("Any")
+
+        self.shiny_type_group = QButtonGroup(self)
+        self.shiny_type_group.addButton(self.shiny_star_radio, 0)
+        self.shiny_type_group.addButton(self.shiny_square_radio, 1)
+        self.shiny_type_group.addButton(self.shiny_any_radio, 2)
+
+        # Set saved type
+        if self.shiny_type == 0:
+            self.shiny_star_radio.setChecked(True)
+        elif self.shiny_type == 1:
+            self.shiny_square_radio.setChecked(True)
+        else:
+            self.shiny_any_radio.setChecked(True)
+
+        # Enable/disable based on always_shiny
+        self.shiny_star_radio.setEnabled(self.always_shiny)
+        self.shiny_square_radio.setEnabled(self.always_shiny)
+        self.shiny_any_radio.setEnabled(self.always_shiny)
+
+        shiny_type_layout.addWidget(self.shiny_star_radio)
+        shiny_type_layout.addWidget(self.shiny_square_radio)
+        shiny_type_layout.addWidget(self.shiny_any_radio)
+        shiny_type_layout.addStretch()
+        layout.addWidget(shiny_type_widget)
+
+        # Alpha search checkbox
+        self.alpha_search_check = QCheckBox("Always search for alpha Pokemon")
+        self.alpha_search_check.setChecked(self.always_alpha)
+        layout.addWidget(self.alpha_search_check)
+
+        # Table for species research levels
+        self.table = QTableWidget()
+        self.table.setColumnCount(2)
+        self.table.setHorizontalHeaderLabels(["Species", "Research Level"])
+        self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.table.setColumnWidth(1, 150)  # Fixed width for dropdown column
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        # Populate table with all species
+        self.populate_species()
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        save_btn.clicked.connect(self.save_settings)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(save_btn)
+        btn_layout.addWidget(cancel_btn)
+        layout.addLayout(btn_layout)
+
+        # Initial update of change_all_combo based on charm state
+        self.update_change_all_combo()
+
+    def populate_species(self):
+        # All species that appear as wild encounters in Pokémon Legends: Arceus
+        # (National Pokédex numbers, excluding forms)
+        hisui_species = [
+            25, 26, 35, 36, 37, 38, 41, 42, 46, 47, 54, 55, 58, 59, 63, 64, 65, 66,
+            67, 68, 72, 73, 74, 75, 76, 77, 78, 81, 82, 92, 93, 94, 95, 100, 101,
+            108, 111, 112, 113, 114, 122, 123, 125, 126, 129, 130, 133, 134, 135,
+            136, 137, 143, 155, 156, 157, 169, 172, 173, 175, 176, 185, 190, 193,
+            196, 197, 198, 200, 201, 207, 208, 211, 212, 214, 215, 216, 217, 220,
+            221, 223, 224, 226, 233, 234, 239, 240, 242, 265, 266, 267, 268, 269,
+            280, 281, 282, 299, 315, 339, 340, 355, 356, 358, 361, 362, 363, 364,
+            365, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399,
+            400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413,
+            414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427,
+            428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441,
+            442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455,
+            456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469,
+            470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483,
+            484, 485, 486, 487, 488, 489, 490, 492, 493, 501, 502, 503, 548, 549,
+            550, 570, 571, 627, 628, 641, 642, 645, 700, 704, 705, 706, 712, 713,
+            722, 723, 724, 899, 900, 901, 902, 903, 904, 905,
+        ]
+        # Sort by name for readability
+        sorted_species = sorted(hisui_species, key=lambda s: get_name_en(s, None))
+
+        self.table.setRowCount(len(sorted_species))
+        for row, species in enumerate(sorted_species):
+            name_item = QTableWidgetItem(get_name_en(species, None))
+            name_item.setData(Qt.UserRole, species)
+            self.table.setItem(row, 0, name_item)
+
+            combo = QComboBox()
+            combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
+            saved_level = self.settings.value(f"species/{species}/researchLevel", 0, int)
+            combo.setCurrentIndex(saved_level)
+            self.table.setCellWidget(row, 1, combo)
+
+        # If the charm was saved as True, ensure no species is still at Base Research
+        if self.shiny_charm:
+            self.apply_charm_rule()
+
+    def apply_charm_rule(self):
+        """For each species, if it's Base Research, set to Research Level 10."""
+        for row in range(self.table.rowCount()):
+            combo = self.table.cellWidget(row, 1)
+            if combo and combo.currentIndex() == 0:
+                combo.setCurrentIndex(1)   # Base -> Level 10
+
+    def update_change_all_combo(self):
+        """Add or remove 'Base Research' from the change-all dropdown based on charm state."""
+        current_index = self.change_all_combo.currentIndex()
+        current_text = self.change_all_combo.currentText()
+        self.change_all_combo.clear()
+        if self.charm_check.isChecked():
+            self.change_all_combo.addItems(["Research Level 10", "Perfect Research"])
+        else:
+            self.change_all_combo.addItems(["Base Research", "Research Level 10", "Perfect Research"])
+        # Try to restore the previous selection if possible
+        index = self.change_all_combo.findText(current_text)
+        if index >= 0:
+            self.change_all_combo.setCurrentIndex(index)
+        else:
+            self.change_all_combo.setCurrentIndex(0)
+
+    def change_all_research_level(self, index):
+        """Set all species combos to the selected research level."""
+        # Map the dropdown index to the actual research level index
+        if self.charm_check.isChecked():
+            # Items: "Research Level 10" (index 0), "Perfect Research" (index 1)
+            # Map to: 1 = Level 10, 2 = Perfect
+            target_level = index + 1
+        else:
+            # Items: "Base Research" (0), "Research Level 10" (1), "Perfect Research" (2)
+            target_level = index
+        for row in range(self.table.rowCount()):
+            combo = self.table.cellWidget(row, 1)
+            if combo:
+                combo.setCurrentIndex(target_level)
+
+    def on_charm_toggled(self, checked):
+        """When charm is checked, upgrade any Base Research to Level 10 and update dropdown."""
+        if checked:
+            self.apply_charm_rule()
+        self.update_change_all_combo()
+
+    def on_shiny_search_toggled(self, checked):
+        """Enable/disable shiny type radio buttons."""
+        self.shiny_star_radio.setEnabled(checked)
+        self.shiny_square_radio.setEnabled(checked)
+        self.shiny_any_radio.setEnabled(checked)
+
+    def save_settings(self):
+        """Write settings to QSettings and accept"""
+        self.settings.setValue("shinyCharm", self.charm_check.isChecked())
+        self.settings.setValue("alwaysSearchShiny", self.shiny_search_check.isChecked())
+        self.settings.setValue("shinyType", self.shiny_type_group.checkedId())
+        self.settings.setValue("alwaysSearchAlpha", self.alpha_search_check.isChecked())
+
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 0)
+            if item is None:
+                continue
+            species = item.data(Qt.UserRole)
+            combo = self.table.cellWidget(row, 1)
+            if combo:
+                level = combo.currentIndex()
+                self.settings.setValue(f"species/{species}/researchLevel", level)
+        self.accept()

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -135,13 +135,6 @@ class GeneratorWindow(QDialog):
         
         self.header_widget = QWidget()
         self.header_layout = QHBoxLayout(self.header_widget)
-
-        self.toggle_settings_display_button = QPushButton("▼ Hide Settings")
-        self.toggle_settings_display_button.setCheckable(True)
-        self.toggle_settings_display_button.setChecked(True)
-        self.toggle_settings_display_button.clicked.connect(self.hide_show_settings)
-        
-        self.header_layout.addWidget(self.toggle_settings_display_button)
         
         def seed_base_changed(index: int) -> None:
             is_hex = index == 0
@@ -291,10 +284,6 @@ class GeneratorWindow(QDialog):
         self.alpha_filter = QCheckBox("Alpha Only")
         self.shortest_path_filter = QCheckBox("Only Shortest Path")
         self.shortest_path_filter.setChecked(True)
-        self.chain_results_filter = QCheckBox("Only Chain Results")
-        
-        self.shortest_path_filter.clicked.connect(self.shortest_path_or_chain_results)
-        self.chain_results_filter.clicked.connect(self.shortest_path_or_chain_results)
 
         self.size_filter, size_widget = labled_widget(
             "Height/Scale:", CheckableComboBox
@@ -310,7 +299,6 @@ class GeneratorWindow(QDialog):
         self.filter_layout.addWidget(size_widget)
         self.filter_layout.addWidget(self.alpha_filter)
         self.filter_layout.addWidget(self.shortest_path_filter)
-        self.filter_layout.addWidget(self.chain_results_filter)
 
         self.iv_filter_widget = QWidget()
         self.iv_filter_layout = QVBoxLayout(self.iv_filter_widget)
@@ -361,11 +349,6 @@ class GeneratorWindow(QDialog):
             self.height(),
         
         )
-        
-    def hide_show_settings(self):
-        visible = self.toggle_settings_display_button.isChecked()
-        self.top_widget.setVisible(visible)
-        self.toggle_settings_display_button.setText("▼ Hide Settings" if visible else "▶ Display Settings")
 
     def generate(self) -> None:
         """Generate paths for spawner"""
@@ -396,8 +379,6 @@ class GeneratorWindow(QDialog):
         shiny_filter = self.shiny_filter.currentData() or 15
         alpha_filter = self.alpha_filter.checkState() == QtCore.Qt.Checked
         shortest_path_filter = self.shortest_path_filter.checkState() == QtCore.Qt.Checked
-        chain_results_filter = self.chain_results_filter.isChecked()
-        
         iv_filters = tuple(
             (iv_range.start, iv_range.stop - 1)
             for iv_range in (iv_filter.get_range() for iv_filter in self.iv_filters)
@@ -539,25 +520,12 @@ class GeneratorWindow(QDialog):
                 
         row_i = self.result_table.rowCount()
         self.result_table.insertRow(row_i)
-        
-        # Wurmple evolution determination by adding an extension -C or -S
-        if species == 265:
-            first_16_bits = (_encryption_constant >> 16) & 0xFFFF
-            if (first_16_bits % 10) > 4:
-                extension = "-Cascoon"
-            else:
-                extension = "-Silcoon"
-        else:
-            extension = ""
-
-        species_name = get_name_en(species, form, is_alpha) + extension
-        
         row = (
             advance,
             path_to_string(path)
             if self.spawner.max_spawn_count != 1
             else "N/A",
-            species_name,
+            get_name_en(species, form, is_alpha),
             "Square" if shiny == 2 else "Star" if shiny else "No",
             "Yes" if is_alpha else "No",
             NATURES_EN[nature],
@@ -573,27 +541,11 @@ class GeneratorWindow(QDialog):
         for j, value in enumerate(row):
             item = QTableWidgetItem()
             item.setData(Qt.EditRole, value)
-            *_, group_id = row
-            if (group_id + 1) % 2:
-                item.setBackground(QColor(35, 55, 75))
             self.result_table.setItem(row_i, j, item)
-            
-        if self.chain_results_filter.isChecked():
-            # Then sort by advances first
-            self.result_table.model().sort(0, Qt.AscendingOrder)
-            # Then sort by paths
-            self.result_table.model().sort(1, Qt.AscendingOrder)
-            # Then sort by group_id
-            self.result_table.model().sort(17, Qt.AscendingOrder)
-                    
-        else:
-            # Sort by paths first
-            self.result_table.model().sort(1, Qt.AscendingOrder)
-            # then by advances
-            self.result_table.model().sort(0, Qt.AscendingOrder)
-            
-        
-        
+        # sort by paths first
+        self.result_table.model().sort(1, Qt.AscendingOrder)
+        # then by advances
+        self.result_table.model().sort(0, Qt.AscendingOrder)
     
     def closeEvent(self, event):
         if self.generator_update_thread is not None:
@@ -617,13 +569,12 @@ class GeneratorUpdateThread(QThread):
     progress = Signal(int)
     new_result = Signal(tuple)
 
-    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, chain_results: bool, *args) -> None:
+    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, *args) -> None:
         super().__init__()
         self.parent_window = parent_window
         self.parent_data_hook = np.zeros(2, np.uint64)
         self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, *args, self.parent_data_hook)
         self.shortest_path_only = shortest_path_only
-        self.chain_results = chain_results
         self.args = args
 
     def run(self) -> None:
@@ -637,9 +588,6 @@ class GeneratorUpdateThread(QThread):
 
         result_count = 0
         result_ids = set()
-        result_paths = set()
-        group_id = 0
-
         while True:
             # checking here ensures final copied data is from after the thread finishes
             thread_finished = (
@@ -651,38 +599,15 @@ class GeneratorUpdateThread(QThread):
             self.progress.emit(progress)
             # copy here to dodge thread issues
             results = list(self.generator_thread.results)
-            if self.chain_results:
-                is_chain_result = False
             if len(results) > result_count:
                 for row in results[result_count:]:
-                    advance, path, species, ec, pid, *_ = row
-                    path_str = path_to_string(path)
-                    result_id = ec | (pid << 32)
-                    
                     if self.shortest_path_only:
+                        result_id = row[3] | (row[4] << 32)
                         if result_id not in result_ids:
-                            self.parent_window.add_result(row, group_id)
+                            self.parent_window.add_result(row)
                             result_ids.add(result_id)
-                    
-                    elif self.chain_results:
-                        # Check path relationships
-                        for row_2 in results[result_count:]:
-                            path_str_2 = path_to_string(row_2[1])
-                            is_chain = path_str.startswith(path_str_2 + "->")
-                            if is_chain and result_id not in result_ids:
-                                result_id_2 = row_2[3] | (row_2[4] << 32)
-                                if result_id_2 not in result_ids or path_str_2 not in result_paths:
-                                    result_ids.add(result_id_2)
-                                    result_paths.add(path_str_2)
-                                    group_id += 1
-                                    self.parent_window.add_result(row_2, group_id)
-                                    
-                                self.parent_window.add_result(row, group_id)
-                                result_ids.add(result_id)
-                                result_paths.add(path_str)
-                                        
                     else:
-                        self.parent_window.add_result(row, group_id)
+                        self.parent_window.add_result(row)
                 result_count = len(results)
             if (
                 progress == total_progress

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -28,9 +28,9 @@ from qtpy.QtWidgets import (
     QTableWidgetItem,
     QSpinBox,
 )
-from qtpy.QtGui import QRegularExpressionValidator
+from qtpy.QtGui import QRegularExpressionValidator, QColor
 from qtpy import QtCore
-from qtpy.QtCore import QThread, Signal, Qt
+from qtpy.QtCore import QThread, Signal, Qt, QSettings
 
 # pylint: enable=no-name-in-module
 
@@ -87,6 +87,7 @@ def labled_widget(
     """Build a labled widget"""
     outer_widget = QWidget()
     layout = QHBoxLayout(outer_widget)
+    layout.setSpacing(2)
     label_widget = QLabel(label)
     layout.addWidget(label_widget)
     widget = widget_constructor(*args, **kwargs)
@@ -96,7 +97,7 @@ def labled_widget(
 
 class GeneratorWindow(QDialog):
     """Spawner generator window"""
-
+    
     def __init__(
         self,
         parent: QWidget,
@@ -131,6 +132,17 @@ class GeneratorWindow(QDialog):
         self.seed_base_combobox = QComboBox()
         self.seed_base_combobox.addItem("Hexadecimal", 16)
         self.seed_base_combobox.addItem("Decimal", 10)
+        
+        self.header_widget = QWidget()
+        self.header_layout = QHBoxLayout(self.header_widget)
+
+        self.toggle_settings_display_button = QPushButton("▼ Hide Settings")
+        self.toggle_settings_display_button.setCheckable(True)
+        self.toggle_settings_display_button.setChecked(True)
+        self.toggle_settings_display_button.clicked.connect(self.hide_show_settings)
+        
+        self.header_layout.addWidget(self.toggle_settings_display_button)
+        
         def seed_base_changed(index: int) -> None:
             is_hex = index == 0
             previous_text = self.seed_input.text()
@@ -148,6 +160,7 @@ class GeneratorWindow(QDialog):
             self.seed_input.setText(
                 (f"{seed_value:X}" if is_hex else f"{seed_value}") if seed_value else ""
             )
+            
         self.seed_base_combobox.currentIndexChanged.connect(seed_base_changed)
         seed_base_changed(0)
         self.settings_layout.addWidget(self.seed_base_combobox)
@@ -170,7 +183,7 @@ class GeneratorWindow(QDialog):
         self.settings_layout.addWidget(time_widget)
         spawn_count_label = QLabel("Spawn Count:")
         spawn_count_label.setVisible(bool(self.spawner.is_mass_outbreak))
-        self.settings_layout.addWidget(spawn_count_label)
+        self.settings_layout.addWidget(spawn_count_label, 2, )
         self.first_wave_spawn_count, first_wave_spawn_count_widget = labled_widget("First Wave:", QSpinBox, minimum=8, maximum=10)
         first_wave_spawn_count_widget.setVisible(bool(self.spawner.is_mass_outbreak))
         self.second_wave_spawn_count, second_wave_spawn_count_widget = labled_widget("Second Wave:", QSpinBox, minimum=6, maximum=8)
@@ -203,6 +216,7 @@ class GeneratorWindow(QDialog):
             shiny_rolls_combobox, shiny_rolls_outer = labled_widget(
                 species_name, QComboBox
             )
+            
             for item in (
                 ("Base Research", 1),
                 ("Research Level 10", 2),
@@ -211,11 +225,29 @@ class GeneratorWindow(QDialog):
                 ("Shiny Charm + Perfect Research", 7),
             ):
                 shiny_rolls_combobox.addItem(*item)
+                
+            # Load settings:
+            settings = QSettings("PLAReverseGUI", "Settings")
+            shiny_charm = settings.value("shinyCharm", False, bool)
+            research_level = settings.value(f"species/{slot.species}/researchLevel", 0, int)  # 0=Base, 1=Level10, 2=Perfect
+
+            # Map to combobox index
+            if research_level == 0:          # Base
+                target_index = 3 if shiny_charm else 0              # Base Research only (charm ignored)
+            elif research_level == 1:        # Level 10
+                target_index = 3 if shiny_charm else 1
+            else:                            # Perfect
+                target_index = 4 if shiny_charm else 2
+
+            shiny_rolls_combobox.setCurrentIndex(target_index)
+            
             self.settings_layout.addWidget(shiny_rolls_outer)
             self.shiny_rolls_comboboxes[
                 slot.species
             ] = shiny_rolls_combobox
-        starting_path_label = QLabel("Spawn Count Values:" if is_variable else "Starting Path:")
+
+        
+        starting_path_label = QLabel("<b>Spawn Count Values:</b>" if is_variable else "<b>Starting Path:</b>")
         starting_path_label.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
         self.settings_layout.addWidget(starting_path_label)
         self.starting_path_input = QLineEdit()
@@ -237,6 +269,7 @@ class GeneratorWindow(QDialog):
             self.species_filter.add_checked_item(
                 get_name_en(*species_form), species_form
             )
+
         self.gender_filter, gender_widget = labled_widget(
             "Gender Filter:", CheckableComboBox
         )
@@ -244,7 +277,7 @@ class GeneratorWindow(QDialog):
         self.gender_filter.add_checked_item("Male", 0)
         self.gender_filter.add_checked_item("Female", 1)
         self.nature_filter, nature_widget = labled_widget(
-            "Nature Filter:", CheckableComboBox
+            "Nature:", CheckableComboBox
         )
         self.nature_filter: CheckableComboBox
         for i, nature in enumerate(NATURES_EN):
@@ -258,14 +291,18 @@ class GeneratorWindow(QDialog):
         self.alpha_filter = QCheckBox("Alpha Only")
         self.shortest_path_filter = QCheckBox("Only Shortest Path")
         self.shortest_path_filter.setChecked(True)
+        self.chain_results_filter = QCheckBox("Only Chain Results")
+        
+        self.shortest_path_filter.clicked.connect(self.shortest_path_or_chain_results)
+        self.chain_results_filter.clicked.connect(self.shortest_path_or_chain_results)
 
         self.size_filter, size_widget = labled_widget(
-            "Height/Scale Filter:", CheckableComboBox
+            "Height/Scale:", CheckableComboBox
         )
         self.size_filter: CheckableComboBox
         self.size_filter.add_checked_item("XXXS (0)", 0)
         self.size_filter.add_checked_item("XXXL (255)", 255)
-
+        
         self.filter_layout.addWidget(species_widget)
         self.filter_layout.addWidget(gender_widget)
         self.filter_layout.addWidget(nature_widget)
@@ -273,6 +310,7 @@ class GeneratorWindow(QDialog):
         self.filter_layout.addWidget(size_widget)
         self.filter_layout.addWidget(self.alpha_filter)
         self.filter_layout.addWidget(self.shortest_path_filter)
+        self.filter_layout.addWidget(self.chain_results_filter)
 
         self.iv_filter_widget = QWidget()
         self.iv_filter_layout = QVBoxLayout(self.iv_filter_widget)
@@ -284,9 +322,10 @@ class GeneratorWindow(QDialog):
             RangeWidget(0, 31, "SpD:"),
             RangeWidget(0, 31, "Spe:"),
         )
+                                                        
         for iv_filter in self.iv_filters:
             self.iv_filter_layout.addWidget(iv_filter)
-
+        
         self.top_layout.addWidget(self.settings_widget)
         self.top_layout.addWidget(self.iv_filter_widget)
         self.top_layout.addWidget(self.filter_widget)
@@ -297,14 +336,36 @@ class GeneratorWindow(QDialog):
         self.generate_button.clicked.connect(self.generate)
 
         self.result_table = ResultTableWidget()
+        self.main_layout.addWidget(self.header_widget)
         self.main_layout.addWidget(self.top_widget)
         self.main_layout.addWidget(self.generate_button)
         self.main_layout.addWidget(self.progress_bar)
         self.main_layout.addWidget(self.result_table)
+        
+        # Apply global search preferences from settings
+        settings = QSettings("PLAReverseGUI", "Settings")
+        if settings.value("alwaysSearchShiny", False, bool):
+            shiny_type = settings.value("shinyType", 2, int)  # 0=Star,1=Square,2=Any
+            # Map to combobox index: Star=1, Square=2, Any=3 (Star/Square)
+            if shiny_type == 0:
+                self.shiny_filter.setCurrentIndex(1)  # Star
+            elif shiny_type == 1:
+                self.shiny_filter.setCurrentIndex(2)  # Square
+            else:
+                self.shiny_filter.setCurrentIndex(3)  # Star/Square
+        if settings.value("alwaysSearchAlpha", False, bool):
+            self.alpha_filter.setChecked(True)
+        
         self.resize(
             sum(column[1] for column in self.result_table.COLUMNS),
             self.height(),
+        
         )
+        
+    def hide_show_settings(self):
+        visible = self.toggle_settings_display_button.isChecked()
+        self.top_widget.setVisible(visible)
+        self.toggle_settings_display_button.setText("▼ Hide Settings" if visible else "▶ Display Settings")
 
     def generate(self) -> None:
         """Generate paths for spawner"""
@@ -335,6 +396,8 @@ class GeneratorWindow(QDialog):
         shiny_filter = self.shiny_filter.currentData() or 15
         alpha_filter = self.alpha_filter.checkState() == QtCore.Qt.Checked
         shortest_path_filter = self.shortest_path_filter.checkState() == QtCore.Qt.Checked
+        chain_results_filter = self.chain_results_filter.isChecked()
+        
         iv_filters = tuple(
             (iv_range.start, iv_range.stop - 1)
             for iv_range in (iv_filter.get_range() for iv_filter in self.iv_filters)
@@ -361,6 +424,7 @@ class GeneratorWindow(QDialog):
                 True,
                 False,
                 shortest_path_filter,
+                chain_results_filter,
                 seed,
                 self.first_wave_spawn_count.value(),
                 self.second_wave_spawn_count.value() if self.has_second_wave else 0,
@@ -380,6 +444,7 @@ class GeneratorWindow(QDialog):
                 False,
                 True,
                 shortest_path_filter,
+                chain_results_filter,
                 seed,
                 starting_path,
                 self.spawner.max_spawn_count,
@@ -400,6 +465,7 @@ class GeneratorWindow(QDialog):
                 False,
                 False,
                 shortest_path_filter,
+                chain_results_filter,
                 seed,
                 starting_path,
                 advance_range.start,
@@ -447,7 +513,7 @@ class GeneratorWindow(QDialog):
         self.result_table.species_info = species_info
         self.result_table.spawn_counts = starting_path
 
-    def add_result(self, row: tuple):
+    def add_result(self, row: tuple, group_id: int):
         (
             advance,
             path,
@@ -470,14 +536,28 @@ class GeneratorWindow(QDialog):
         display_size_imperial = calc_display_size(
             personal_index, height, weight, imperial=True
         )
+                
         row_i = self.result_table.rowCount()
         self.result_table.insertRow(row_i)
+        
+        # Wurmple evolution determination by adding an extension -C or -S
+        if species == 265:
+            first_16_bits = (_encryption_constant >> 16) & 0xFFFF
+            if (first_16_bits % 10) > 4:
+                extension = "-Cascoon"
+            else:
+                extension = "-Silcoon"
+        else:
+            extension = ""
+
+        species_name = get_name_en(species, form, is_alpha) + extension
+        
         row = (
             advance,
             path_to_string(path)
             if self.spawner.max_spawn_count != 1
             else "N/A",
-            get_name_en(species, form, is_alpha),
+            species_name,
             "Square" if shiny == 2 else "Star" if shiny else "No",
             "Yes" if is_alpha else "No",
             NATURES_EN[nature],
@@ -488,21 +568,46 @@ class GeneratorWindow(QDialog):
             "♂" if gender == 0 else "♀" if gender == 1 else "○",
             f"{display_size_metric[0]:.02f} m | {display_size_imperial[0][0]:.00f}'{display_size_imperial[0][1]:.00f}\" ({height})",
             f"{display_size_metric[1]:.02f} kg | {display_size_imperial[1]:.01f} lbs ({weight})",
+            group_id,
         )
         for j, value in enumerate(row):
             item = QTableWidgetItem()
             item.setData(Qt.EditRole, value)
+            *_, group_id = row
+            if (group_id + 1) % 2:
+                item.setBackground(QColor(35, 55, 75))
             self.result_table.setItem(row_i, j, item)
-        # sort by paths first
-        self.result_table.model().sort(1, Qt.AscendingOrder)
-        # then by advances
-        self.result_table.model().sort(0, Qt.AscendingOrder)
-
+            
+        if self.chain_results_filter.isChecked():
+            # Then sort by advances first
+            self.result_table.model().sort(0, Qt.AscendingOrder)
+            # Then sort by paths
+            self.result_table.model().sort(1, Qt.AscendingOrder)
+            # Then sort by group_id
+            self.result_table.model().sort(17, Qt.AscendingOrder)
+                    
+        else:
+            # Sort by paths first
+            self.result_table.model().sort(1, Qt.AscendingOrder)
+            # then by advances
+            self.result_table.model().sort(0, Qt.AscendingOrder)
+            
+        
+        
+    
     def closeEvent(self, event):
         if self.generator_update_thread is not None:
             self.generator_update_thread.requestInterruption()
             self.generator_update_thread.wait()
         event.accept()
+        
+    def shortest_path_or_chain_results(self):
+        """Ensures that Only shortest path and chain results are exclusive"""
+        if self.sender().isChecked():
+            if self.sender() == self.shortest_path_filter:
+                self.chain_results_filter.setChecked(False)
+            else:
+                self.shortest_path_filter.setChecked(False)
 
 
 class GeneratorUpdateThread(QThread):
@@ -512,12 +617,13 @@ class GeneratorUpdateThread(QThread):
     progress = Signal(int)
     new_result = Signal(tuple)
 
-    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, *args) -> None:
+    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, chain_results: bool, *args) -> None:
         super().__init__()
         self.parent_window = parent_window
         self.parent_data_hook = np.zeros(2, np.uint64)
         self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, *args, self.parent_data_hook)
         self.shortest_path_only = shortest_path_only
+        self.chain_results = chain_results
         self.args = args
 
     def run(self) -> None:
@@ -531,6 +637,9 @@ class GeneratorUpdateThread(QThread):
 
         result_count = 0
         result_ids = set()
+        result_paths = set()
+        group_id = 0
+
         while True:
             # checking here ensures final copied data is from after the thread finishes
             thread_finished = (
@@ -542,15 +651,38 @@ class GeneratorUpdateThread(QThread):
             self.progress.emit(progress)
             # copy here to dodge thread issues
             results = list(self.generator_thread.results)
+            if self.chain_results:
+                is_chain_result = False
             if len(results) > result_count:
                 for row in results[result_count:]:
+                    advance, path, species, ec, pid, *_ = row
+                    path_str = path_to_string(path)
+                    result_id = ec | (pid << 32)
+                    
                     if self.shortest_path_only:
-                        result_id = row[3] | (row[4] << 32)
                         if result_id not in result_ids:
-                            self.parent_window.add_result(row)
+                            self.parent_window.add_result(row, group_id)
                             result_ids.add(result_id)
+                    
+                    elif self.chain_results:
+                        # Check path relationships
+                        for row_2 in results[result_count:]:
+                            path_str_2 = path_to_string(row_2[1])
+                            is_chain = path_str.startswith(path_str_2 + "->")
+                            if is_chain and result_id not in result_ids:
+                                result_id_2 = row_2[3] | (row_2[4] << 32)
+                                if result_id_2 not in result_ids or path_str_2 not in result_paths:
+                                    result_ids.add(result_id_2)
+                                    result_paths.add(path_str_2)
+                                    group_id += 1
+                                    self.parent_window.add_result(row_2, group_id)
+                                    
+                                self.parent_window.add_result(row, group_id)
+                                result_ids.add(result_id)
+                                result_paths.add(path_str)
+                                        
                     else:
-                        self.parent_window.add_result(row)
+                        self.parent_window.add_result(row, group_id)
                 result_count = len(results)
             if (
                 progress == total_progress

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -131,7 +131,6 @@ class GeneratorWindow(QDialog):
         self.seed_base_combobox = QComboBox()
         self.seed_base_combobox.addItem("Hexadecimal", 16)
         self.seed_base_combobox.addItem("Decimal", 10)
-
         def seed_base_changed(index: int) -> None:
             is_hex = index == 0
             previous_text = self.seed_input.text()
@@ -149,7 +148,7 @@ class GeneratorWindow(QDialog):
             self.seed_input.setText(
                 (f"{seed_value:X}" if is_hex else f"{seed_value}") if seed_value else ""
             )
-            
+
         self.seed_base_combobox.currentIndexChanged.connect(seed_base_changed)
         seed_base_changed(0)
         self.settings_layout.addWidget(self.seed_base_combobox)
@@ -233,8 +232,6 @@ class GeneratorWindow(QDialog):
             self.shiny_rolls_comboboxes[
                 slot.species
             ] = shiny_rolls_combobox
-
-        
         starting_path_label = QLabel("Spawn Count Values:" if is_variable else "Starting Path:")
         starting_path_label.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
         self.settings_layout.addWidget(starting_path_label)
@@ -257,7 +254,6 @@ class GeneratorWindow(QDialog):
             self.species_filter.add_checked_item(
                 get_name_en(*species_form), species_form
             )
-
         self.gender_filter, gender_widget = labled_widget(
             "Gender Filter:", CheckableComboBox
         )
@@ -305,7 +301,6 @@ class GeneratorWindow(QDialog):
             RangeWidget(0, 31, "SpD:"),
             RangeWidget(0, 31, "Spe:"),
         )
-
         for iv_filter in self.iv_filters:
             self.iv_filter_layout.addWidget(iv_filter)
 
@@ -437,7 +432,6 @@ class GeneratorWindow(QDialog):
                 False,
                 False,
                 shortest_path_filter,
-                chain_results_filter,
                 seed,
                 starting_path,
                 advance_range.start,
@@ -508,7 +502,6 @@ class GeneratorWindow(QDialog):
         display_size_imperial = calc_display_size(
             personal_index, height, weight, imperial=True
         )
-
         row_i = self.result_table.rowCount()
         self.result_table.insertRow(row_i)
         row = (

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import (
     QTableWidgetItem,
     QSpinBox,
 )
-from qtpy.QtGui import QRegularExpressionValidator, QColor
+from qtpy.QtGui import QRegularExpressionValidator
 from qtpy import QtCore
 from qtpy.QtCore import QThread, Signal, Qt, QSettings
 
@@ -87,7 +87,6 @@ def labled_widget(
     """Build a labled widget"""
     outer_widget = QWidget()
     layout = QHBoxLayout(outer_widget)
-    layout.setSpacing(2)
     label_widget = QLabel(label)
     layout.addWidget(label_widget)
     widget = widget_constructor(*args, **kwargs)
@@ -97,7 +96,7 @@ def labled_widget(
 
 class GeneratorWindow(QDialog):
     """Spawner generator window"""
-    
+
     def __init__(
         self,
         parent: QWidget,
@@ -132,10 +131,7 @@ class GeneratorWindow(QDialog):
         self.seed_base_combobox = QComboBox()
         self.seed_base_combobox.addItem("Hexadecimal", 16)
         self.seed_base_combobox.addItem("Decimal", 10)
-        
-        self.header_widget = QWidget()
-        self.header_layout = QHBoxLayout(self.header_widget)
-        
+
         def seed_base_changed(index: int) -> None:
             is_hex = index == 0
             previous_text = self.seed_input.text()
@@ -176,7 +172,7 @@ class GeneratorWindow(QDialog):
         self.settings_layout.addWidget(time_widget)
         spawn_count_label = QLabel("Spawn Count:")
         spawn_count_label.setVisible(bool(self.spawner.is_mass_outbreak))
-        self.settings_layout.addWidget(spawn_count_label, 2, )
+        self.settings_layout.addWidget(spawn_count_label)
         self.first_wave_spawn_count, first_wave_spawn_count_widget = labled_widget("First Wave:", QSpinBox, minimum=8, maximum=10)
         first_wave_spawn_count_widget.setVisible(bool(self.spawner.is_mass_outbreak))
         self.second_wave_spawn_count, second_wave_spawn_count_widget = labled_widget("Second Wave:", QSpinBox, minimum=6, maximum=8)
@@ -209,7 +205,6 @@ class GeneratorWindow(QDialog):
             shiny_rolls_combobox, shiny_rolls_outer = labled_widget(
                 species_name, QComboBox
             )
-            
             for item in (
                 ("Base Research", 1),
                 ("Research Level 10", 2),
@@ -240,7 +235,7 @@ class GeneratorWindow(QDialog):
             ] = shiny_rolls_combobox
 
         
-        starting_path_label = QLabel("<b>Spawn Count Values:</b>" if is_variable else "<b>Starting Path:</b>")
+        starting_path_label = QLabel("Spawn Count Values:" if is_variable else "Starting Path:")
         starting_path_label.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
         self.settings_layout.addWidget(starting_path_label)
         self.starting_path_input = QLineEdit()
@@ -270,7 +265,7 @@ class GeneratorWindow(QDialog):
         self.gender_filter.add_checked_item("Male", 0)
         self.gender_filter.add_checked_item("Female", 1)
         self.nature_filter, nature_widget = labled_widget(
-            "Nature:", CheckableComboBox
+            "Nature Filter:", CheckableComboBox
         )
         self.nature_filter: CheckableComboBox
         for i, nature in enumerate(NATURES_EN):
@@ -286,12 +281,12 @@ class GeneratorWindow(QDialog):
         self.shortest_path_filter.setChecked(True)
 
         self.size_filter, size_widget = labled_widget(
-            "Height/Scale:", CheckableComboBox
+            "Height/Scale Filter:", CheckableComboBox
         )
         self.size_filter: CheckableComboBox
         self.size_filter.add_checked_item("XXXS (0)", 0)
         self.size_filter.add_checked_item("XXXL (255)", 255)
-        
+
         self.filter_layout.addWidget(species_widget)
         self.filter_layout.addWidget(gender_widget)
         self.filter_layout.addWidget(nature_widget)
@@ -310,10 +305,10 @@ class GeneratorWindow(QDialog):
             RangeWidget(0, 31, "SpD:"),
             RangeWidget(0, 31, "Spe:"),
         )
-                                                        
+
         for iv_filter in self.iv_filters:
             self.iv_filter_layout.addWidget(iv_filter)
-        
+
         self.top_layout.addWidget(self.settings_widget)
         self.top_layout.addWidget(self.iv_filter_widget)
         self.top_layout.addWidget(self.filter_widget)
@@ -324,7 +319,6 @@ class GeneratorWindow(QDialog):
         self.generate_button.clicked.connect(self.generate)
 
         self.result_table = ResultTableWidget()
-        self.main_layout.addWidget(self.header_widget)
         self.main_layout.addWidget(self.top_widget)
         self.main_layout.addWidget(self.generate_button)
         self.main_layout.addWidget(self.progress_bar)
@@ -347,7 +341,6 @@ class GeneratorWindow(QDialog):
         self.resize(
             sum(column[1] for column in self.result_table.COLUMNS),
             self.height(),
-        
         )
 
     def generate(self) -> None:
@@ -405,7 +398,6 @@ class GeneratorWindow(QDialog):
                 True,
                 False,
                 shortest_path_filter,
-                chain_results_filter,
                 seed,
                 self.first_wave_spawn_count.value(),
                 self.second_wave_spawn_count.value() if self.has_second_wave else 0,
@@ -425,7 +417,6 @@ class GeneratorWindow(QDialog):
                 False,
                 True,
                 shortest_path_filter,
-                chain_results_filter,
                 seed,
                 starting_path,
                 self.spawner.max_spawn_count,
@@ -494,7 +485,7 @@ class GeneratorWindow(QDialog):
         self.result_table.species_info = species_info
         self.result_table.spawn_counts = starting_path
 
-    def add_result(self, row: tuple, group_id: int):
+    def add_result(self, row: tuple):
         (
             advance,
             path,
@@ -517,7 +508,7 @@ class GeneratorWindow(QDialog):
         display_size_imperial = calc_display_size(
             personal_index, height, weight, imperial=True
         )
-                
+
         row_i = self.result_table.rowCount()
         self.result_table.insertRow(row_i)
         row = (
@@ -536,7 +527,6 @@ class GeneratorWindow(QDialog):
             "♂" if gender == 0 else "♀" if gender == 1 else "○",
             f"{display_size_metric[0]:.02f} m | {display_size_imperial[0][0]:.00f}'{display_size_imperial[0][1]:.00f}\" ({height})",
             f"{display_size_metric[1]:.02f} kg | {display_size_imperial[1]:.01f} lbs ({weight})",
-            group_id,
         )
         for j, value in enumerate(row):
             item = QTableWidgetItem()
@@ -546,20 +536,12 @@ class GeneratorWindow(QDialog):
         self.result_table.model().sort(1, Qt.AscendingOrder)
         # then by advances
         self.result_table.model().sort(0, Qt.AscendingOrder)
-    
+
     def closeEvent(self, event):
         if self.generator_update_thread is not None:
             self.generator_update_thread.requestInterruption()
             self.generator_update_thread.wait()
         event.accept()
-        
-    def shortest_path_or_chain_results(self):
-        """Ensures that Only shortest path and chain results are exclusive"""
-        if self.sender().isChecked():
-            if self.sender() == self.shortest_path_filter:
-                self.chain_results_filter.setChecked(False)
-            else:
-                self.shortest_path_filter.setChecked(False)
 
 
 class GeneratorUpdateThread(QThread):

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -148,7 +148,6 @@ class GeneratorWindow(QDialog):
             self.seed_input.setText(
                 (f"{seed_value:X}" if is_hex else f"{seed_value}") if seed_value else ""
             )
-
         self.seed_base_combobox.currentIndexChanged.connect(seed_base_changed)
         seed_base_changed(0)
         self.settings_layout.addWidget(self.seed_base_combobox)

--- a/pla_reverse_gui/window/map_window.py
+++ b/pla_reverse_gui/window/map_window.py
@@ -27,8 +27,10 @@ from qtpy.QtWidgets import (
 
 from ..util import get_name_en
 from .seed_finder_window import SeedFinderWindow
+from ..settings_dialog import SettingsDialog
 from .generator_window import GeneratorWindow
 from .checkable_combobox_widget import CheckableComboBox
+
 
 
 class MapWindow(QWidget):
@@ -93,6 +95,8 @@ class MapWindow(QWidget):
         )
         self.second_wave_combobox.setHidden(True)
         self.spawner_summary = QLabel("")
+        self.settings_button = QPushButton("Settings")
+        self.settings_button.clicked.connect(self.open_settings)
         self.seed_finder_button = QPushButton("Seed Finder")
         self.seed_finder_button.clicked.connect(self.open_seed_finder)
         self.generator_button = QPushButton("Open Generator")
@@ -104,6 +108,7 @@ class MapWindow(QWidget):
         self.options_layout.addWidget(self.first_wave_combobox)
         self.options_layout.addWidget(self.second_wave_combobox)
         self.options_layout.addWidget(self.spawner_summary)
+        self.options_layout.addWidget(self.settings_button)
         self.options_layout.addWidget(self.seed_finder_button)
         self.options_layout.addWidget(self.generator_button)
 
@@ -463,6 +468,11 @@ class MapWindow(QWidget):
             f"{marker.jsName}.setIcon({self.selected_marker_icon.jsName})"
         )
         self.selected_marker = marker
+        
+    def open_settings(self) -> None:
+        """Open the preferences dialog"""
+        dlg = SettingsDialog(self)
+        dlg.exec_()
 
     def open_seed_finder(self) -> None:
         """Open Seed Finder for spawner"""

--- a/pla_reverse_gui/window/map_window.py
+++ b/pla_reverse_gui/window/map_window.py
@@ -32,7 +32,6 @@ from .generator_window import GeneratorWindow
 from .checkable_combobox_widget import CheckableComboBox
 
 
-
 class MapWindow(QWidget):
     """QWidget window for main map display"""
 

--- a/pla_reverse_gui/window/seed_finder_window.py
+++ b/pla_reverse_gui/window/seed_finder_window.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
 )
 
 # pylint: enable=no-name-in-module
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QSettings
 
 from .pokemon_info_widget import PokemonInfoWidget
 from .eta_progress_bar import ETAProgressBar
@@ -106,6 +106,39 @@ class SeedFinderWindow(QDialog):
             spawner,
             encounter_table,
         )
+        
+        # Load settings and apply to the two Pokemon widgets
+        settings = QSettings("PLAReverseGUI", "Settings")
+        global_shiny_charm = settings.value("shinyCharm", False, bool)
+
+        def update_shiny_rolls_from_settings(widget):
+            species = widget.species_combobox.currentData()
+            if species is None:
+                return
+            research_level = settings.value(f"species/{species}/researchLevel", 0, int)
+            # Map research level and charm to combobox index (same as generator window)
+            if research_level == 0:          # Base
+                target_index = 3 if global_shiny_charm else 0
+            elif research_level == 1:        # Level 10
+                target_index = 3 if global_shiny_charm else 1
+            else:                            # Perfect
+                target_index = 4 if global_shiny_charm else 2
+            # Ensure the combobox has at least these items
+            if widget.shiny_rolls_combobox.count() > target_index:
+                widget.shiny_rolls_combobox.setCurrentIndex(target_index)
+
+        # Apply initial settings
+        update_shiny_rolls_from_settings(self.pokemon_1)
+        update_shiny_rolls_from_settings(self.pokemon_2)
+
+        # Connect species change signals to keep shiny rolls updated
+        self.pokemon_1.species_combobox.currentIndexChanged.connect(
+            lambda: update_shiny_rolls_from_settings(self.pokemon_1)
+        )
+        self.pokemon_2.species_combobox.currentIndexChanged.connect(
+            lambda: update_shiny_rolls_from_settings(self.pokemon_2)
+        )
+        
         self.compute_seed_button = QPushButton("Compute Group Seed")
         self.compute_seed_button.clicked.connect(self.compute_seed)
 


### PR DESCRIPTION
After using PLA-reverse for some time, I noticed that I would often enter the Dex research levels, the shiny filter and tick the Alpha only box. It has even happened to me that I wouldn't tick those and click Generate: the overload of results would crash the program. So I thought that it would be nice to add settings that apply to all pokemon so that you don't ever have to set those again.