### PR TITLE
Option allowing other starting paths and other initial spawn options for variable multispawners

### DIFF
--- a/pla_reverse_gui/generator.py
+++ b/pla_reverse_gui/generator.py
@@ -212,6 +212,7 @@ def generate_mass_outbreak(
 def generate_variable(
     seed: np.uint64,
     allow_other_starts: bool,
+    initial_spawns: int,
     count_values: tuple[int],
     max_spawn_count: int,
     encounter_table: EncounterAreaLA,
@@ -241,14 +242,20 @@ def generate_variable(
     fixed_rng = Xoroshiro128PlusRejection(0, 0)
 
     queue = []
-    # variable multis always start by catching 2 isolated pokemon
-    queue.append(([np.uint8(2)], advance_seed(seed, 2), 0, 2))
-    # If given the option, the generator can also check starting from 0, 1 or 3
-    if allow_other_starts:
-        queue.append(([np.uint8(0)], advance_seed(seed, 0), 0, 0))
-        queue.append(([np.uint8(1)], advance_seed(seed, 1), 0, 1))
-        if max_spawn_count == 3:
-            queue.append(([np.uint8(3)], advance_seed(seed, 3), 0, 3))
+
+    for i in range(initial_spawns + 1):
+        # If it's 1, then it's the 1->1 path
+        if initial_spawns == 1:
+            for j in range(initial_spawns + 1):
+                # If the user chooses to allow other starts, 0->0, 0->1 and 1->0 will be included, and if not only 1->1 starts will be included in the queue
+                if i == 1 and j == 1 or allow_other_starts:
+                    queue.append(([np.uint8(i), np.uint8(j)], advance_seed(advance_seed(seed, i), j), 0, 1))
+        # If it's 2 or 3
+        else:
+            # If the user chooses to allow other starts, 0->, 1->, 2->, (3-> if /3 spawner) will be included, if not only the initial spawn number will be included in the queue
+            if i == initial_spawns or allow_other_starts:
+                queue.append(([np.uint8(i)], advance_seed(seed, i), 0, 3))
+        
     initial_advances = len(queue[0][0])
     # check parent_data[1] flag each item
     while len(queue) != 0 and parent_data[1] == 0:
@@ -365,6 +372,7 @@ def generate_variable(
 def generate_standard(
     seed: np.uint64,
     allow_other_starts: bool,
+    initial_spawns,
     starting_path: tuple[int],
     min_adv: int,
     max_adv: int,
@@ -403,7 +411,7 @@ def generate_standard(
         elif spawn_count > 1:
             # triple/double spawners always start by catching the two mons there
             queue.append(([np.uint8(2)], advance_seed(seed, spawn_count)))
-            
+
             if allow_other_starts:
                 queue.append(([np.uint8(1)], advance_seed(seed, spawn_count)))
         if spawn_count == 3:

--- a/pla_reverse_gui/generator.py
+++ b/pla_reverse_gui/generator.py
@@ -211,6 +211,7 @@ def generate_mass_outbreak(
 @numba.njit(nogil=True)
 def generate_variable(
     seed: np.uint64,
+    allow_other_starts: bool,
     count_values: tuple[int],
     max_spawn_count: int,
     encounter_table: EncounterAreaLA,
@@ -242,6 +243,12 @@ def generate_variable(
     queue = []
     # variable multis always start by catching 2 isolated pokemon
     queue.append(([np.uint8(2)], advance_seed(seed, 2), 0, 2))
+    # If given the option, the generator can also check starting from 0, 1 or 3
+    if allow_other_starts:
+        queue.append(([np.uint8(0)], advance_seed(seed, 0), 0, 0))
+        queue.append(([np.uint8(1)], advance_seed(seed, 1), 0, 1))
+        if max_spawn_count == 3:
+            queue.append(([np.uint8(3)], advance_seed(seed, 3), 0, 3))
     initial_advances = len(queue[0][0])
     # check parent_data[1] flag each item
     while len(queue) != 0 and parent_data[1] == 0:
@@ -357,6 +364,7 @@ def generate_variable(
 @numba.njit(nogil=True)
 def generate_standard(
     seed: np.uint64,
+    allow_other_starts: bool,
     starting_path: tuple[int],
     min_adv: int,
     max_adv: int,
@@ -395,6 +403,9 @@ def generate_standard(
         elif spawn_count > 1:
             # triple/double spawners always start by catching the two mons there
             queue.append(([np.uint8(2)], advance_seed(seed, spawn_count)))
+            
+            if allow_other_starts:
+                queue.append(([np.uint8(1)], advance_seed(seed, spawn_count)))
         if spawn_count == 3:
             # triple spawners also have the option of catching the third mon
             queue.append(([np.uint8(3)], advance_seed(seed, spawn_count)))

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -215,6 +215,9 @@ class GeneratorWindow(QDialog):
             self.shiny_rolls_comboboxes[
                 slot.species
             ] = shiny_rolls_combobox
+        self.allow_other_starts_checkbox = QCheckBox("Allow paths that do not start with catch-2")
+        self.allow_other_starts_checkbox.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
+        self.settings_layout.addWidget(self.allow_other_starts_checkbox)
         starting_path_label = QLabel("Spawn Count Values:" if is_variable else "Starting Path:")
         starting_path_label.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
         self.settings_layout.addWidget(starting_path_label)
@@ -380,6 +383,7 @@ class GeneratorWindow(QDialog):
                 False,
                 True,
                 shortest_path_filter,
+                self.allow_other_starts_checkbox.isChecked(),
                 seed,
                 starting_path,
                 self.spawner.max_spawn_count,
@@ -400,6 +404,7 @@ class GeneratorWindow(QDialog):
                 False,
                 False,
                 shortest_path_filter,
+                self.allow_other_starts_checkbox.isChecked(),
                 seed,
                 starting_path,
                 advance_range.start,
@@ -512,12 +517,13 @@ class GeneratorUpdateThread(QThread):
     progress = Signal(int)
     new_result = Signal(tuple)
 
-    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, *args) -> None:
+    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, allow_other_starts: bool, *args) -> None:
         super().__init__()
         self.parent_window = parent_window
         self.parent_data_hook = np.zeros(2, np.uint64)
-        self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, *args, self.parent_data_hook)
+        self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, allow_other_starts, *args, self.parent_data_hook)
         self.shortest_path_only = shortest_path_only
+        self.allow_other_starts = allow_other_starts
         self.args = args
 
     def run(self) -> None:
@@ -566,10 +572,11 @@ class GeneratorThread(QThread):
 
     finished = Signal()
 
-    def __init__(self, is_outbreak: bool, is_variable: bool, *args) -> None:
+    def __init__(self, is_outbreak: bool, is_variable: bool, allow_other_starts: bool, *args) -> None:
         super().__init__()
         self.is_outbreak = is_outbreak
         self.is_variable = is_variable
+        self.allow_other_starts = allow_other_starts
         self.args = args
         self.results = TypedList.empty_list(
             item_type=numba.typeof(
@@ -595,7 +602,7 @@ class GeneratorThread(QThread):
         if self.is_outbreak:
             generate_mass_outbreak(*self.args, self.results)
         elif self.is_variable:
-            generate_variable(*self.args, self.results)
+            generate_variable(self.args[0], self.allow_other_starts, *self.args[1:], self.results)
         else:
-            generate_standard(*self.args, self.results)
+            generate_standard(self.args[0], self.allow_other_starts, *self.args[1:], self.results)
         self.finished.emit()

--- a/pla_reverse_gui/window/generator_window.py
+++ b/pla_reverse_gui/window/generator_window.py
@@ -43,23 +43,28 @@ from ..pla_reverse_main.pla_reverse.size import calc_display_size
 from .eta_progress_bar import ETAProgressBar
 
 
-def compute_result_count(max_spawn_count: int, max_path_length: int) -> int:
-    """Calculate the total amount of results to be generated for a given spawner and max path length"""
+def compute_result_count(max_spawn_count: int, max_path_length: int, allow_other_starts: bool) -> int:
+    """Calculate the total amount of results to be generated for a given spawner, max path length and if the user allows other starting paths"""
     if max_spawn_count == 1:
         return max_path_length
-    initial_value = 1 if max_spawn_count != 3 else 2
+    if max_spawn_count == 4:
+        initial_value = 1
+    else:
+        ## In the case of 2 or 3 max spawn counts
+        initial_value = (max_spawn_count - 1) + allow_other_starts * 1
     return initial_value * (1 - max_spawn_count**max_path_length) // (1 - max_spawn_count)
 
-def compute_result_count_variable(spawn_counts: list[int]):
+def compute_result_count_variable(spawn_counts: list[int], allow_other_starts: bool):
     """Calculate the total amount of results to be generated for a given variable multi spawner"""
     # number of results at each step that have the corresponding num_spawned
+    max_spawn_count = max(spawn_counts)
     counts = {
         1: 0,
         # variable spawners always start with 2 spawns
         2: 1,
         3: 0
     }
-    total_result_count = sum(counts.values())
+    total = sum(counts.values())
     for spawn_count in spawn_counts[1:]:
         new_counts = {
             1: 0,
@@ -76,10 +81,13 @@ def compute_result_count_variable(spawn_counts: list[int]):
                 # or increase to spawn_count
                 # (this loop is the same as just looping over num_spawned - ko_count in reverse)
                 new_counts[max(num_spawned - ko_count, spawn_count)] += counts[num_spawned]
-        total_result_count += sum(new_counts.values())
+        total += sum(new_counts.values())
         counts = new_counts
-
-    return total_result_count
+        # Multiply by number of allowed initial ko values if option enabled
+    if allow_other_starts:
+        multiplier = 3 if max_spawn_count == 2 else 4
+        total *= multiplier
+    return total
 
 def labled_widget(
     label: str, widget_constructor: QWidget, *args, **kwargs
@@ -218,16 +226,47 @@ class GeneratorWindow(QDialog):
         self.allow_other_starts_checkbox = QCheckBox("Allow paths that do not start with catch-2")
         self.allow_other_starts_checkbox.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
         self.settings_layout.addWidget(self.allow_other_starts_checkbox)
-        starting_path_label = QLabel("Spawn Count Values:" if is_variable else "Starting Path:")
+        
+        if is_variable:
+            initial_spawn_options = []
+            
+            if self.spawner.min_spawn_count == 1:
+                initial_spawn_options.append("1->1")
+            initial_spawn_options.append("2")
+            if self.spawner.max_spawn_count == 3:
+                initial_spawn_options.append("3")
+            
+            spawn_count_extended = QHBoxLayout()
+            
+            initial_spawn_layout = QVBoxLayout()
+            self.initial_spawn_label = QLabel("Initial\nspawns:")
+            initial_spawn_layout.addWidget(self.initial_spawn_label)
+            self.initial_spawn_box = QComboBox()
+            self.initial_spawn_box.addItems(initial_spawn_options)
+            initial_spawn_layout.addWidget(self.initial_spawn_box)
+            
+            spawn_count_layout = QVBoxLayout()
+            starting_path_label = QLabel("Spawn Count Values:")
+            spawn_count_layout.addWidget(starting_path_label)
+            self.starting_path_input = QLineEdit()
+            spawn_count_layout.addWidget(self.starting_path_input)
+            
+            spawn_count_extended.addLayout(initial_spawn_layout)
+            spawn_count_extended.addLayout(spawn_count_layout)
+            self.settings_layout.addLayout(spawn_count_extended)
+            
+        else:
+            starting_path_label = QLabel("Starting Path:")
+            self.settings_layout.addWidget(starting_path_label)
+            self.starting_path_input = QLineEdit()
+            self.settings_layout.addWidget(self.starting_path_input)
+        
         starting_path_label.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
-        self.settings_layout.addWidget(starting_path_label)
-        self.starting_path_input = QLineEdit()
         # TODO: regex validation
         # self.starting_path_input.setValidator(
         #     QRegularExpressionValidator(QtCore.QRegularExpression(""))
         # )
         self.starting_path_input.setVisible(self.spawner.max_spawn_count > 1 and not self.spawner.is_mass_outbreak)
-        self.settings_layout.addWidget(self.starting_path_input)
 
         self.filter_widget = QWidget()
         self.filter_layout = QVBoxLayout(self.filter_widget)
@@ -335,6 +374,14 @@ class GeneratorWindow(QDialog):
         filtered_genders = self.gender_filter.get_checked_values()
         filtered_natures = self.nature_filter.get_checked_values()
         filtered_sizes = self.size_filter.get_checked_values()
+        # Parse initial spawns for variable spawners – use first character as integer
+        if hasattr(self, 'initial_spawn_box'):
+            selected = self.initial_spawn_box.currentText()
+            # "1->1" becomes 1, "2" becomes 2, "3" becomes 3
+            initial_spawns = int(selected[0])
+        else:
+            initial_spawns = 0
+            
         shiny_filter = self.shiny_filter.currentData() or 15
         alpha_filter = self.alpha_filter.checkState() == QtCore.Qt.Checked
         shortest_path_filter = self.shortest_path_filter.checkState() == QtCore.Qt.Checked
@@ -353,10 +400,12 @@ class GeneratorWindow(QDialog):
                 len(filtered_species) == 0 or (species, form) in filtered_species,
             )
 
-        if self.spawner.is_mass_outbreak or self.spawner.min_spawn_count != self.spawner.max_spawn_count:
-            self.progress_bar.setMaximum(compute_result_count_variable(starting_path))
+        if self.spawner.is_mass_outbreak:
+            self.progress_bar.setMaximum(compute_result_count(starting_path))
+        elif self.spawner.min_spawn_count != self.spawner.max_spawn_count:
+            self.progress_bar.setMaximum(compute_result_count_variable(starting_path, self.allow_other_starts_checkbox.isChecked()))
         else:
-            self.progress_bar.setMaximum(compute_result_count(self.spawner.max_spawn_count, advance_range.stop))
+            self.progress_bar.setMaximum(compute_result_count(self.spawner.max_spawn_count, advance_range.stop, self.allow_other_starts_checkbox.isChecked()))
 
         if self.spawner.is_mass_outbreak:
             self.generator_update_thread = GeneratorUpdateThread(
@@ -364,6 +413,8 @@ class GeneratorWindow(QDialog):
                 True,
                 False,
                 shortest_path_filter,
+                self.allow_other_starts_checkbox.isChecked(),
+                initial_spawns,
                 seed,
                 self.first_wave_spawn_count.value(),
                 self.second_wave_spawn_count.value() if self.has_second_wave else 0,
@@ -384,6 +435,7 @@ class GeneratorWindow(QDialog):
                 True,
                 shortest_path_filter,
                 self.allow_other_starts_checkbox.isChecked(),
+                initial_spawns,
                 seed,
                 starting_path,
                 self.spawner.max_spawn_count,
@@ -405,6 +457,7 @@ class GeneratorWindow(QDialog):
                 False,
                 shortest_path_filter,
                 self.allow_other_starts_checkbox.isChecked(),
+                initial_spawns,
                 seed,
                 starting_path,
                 advance_range.start,
@@ -517,13 +570,14 @@ class GeneratorUpdateThread(QThread):
     progress = Signal(int)
     new_result = Signal(tuple)
 
-    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, allow_other_starts: bool, *args) -> None:
+    def __init__(self, parent_window: GeneratorWindow, is_mass_outbreak: bool, is_variable: bool, shortest_path_only: bool, allow_other_starts: bool, initial_spawns: int, *args) -> None:
         super().__init__()
         self.parent_window = parent_window
         self.parent_data_hook = np.zeros(2, np.uint64)
-        self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, allow_other_starts, *args, self.parent_data_hook)
+        self.generator_thread = GeneratorThread(is_mass_outbreak, is_variable, allow_other_starts, initial_spawns, *args, self.parent_data_hook)
         self.shortest_path_only = shortest_path_only
         self.allow_other_starts = allow_other_starts
+        self.initial_spawns = initial_spawns
         self.args = args
 
     def run(self) -> None:
@@ -531,9 +585,9 @@ class GeneratorUpdateThread(QThread):
         self.generator_thread.start()
 
         if isinstance(self.args[3], EncounterAreaLA):
-            total_progress = compute_result_count_variable(self.args[1])
+            total_progress = compute_result_count_variable(self.args[1], self.allow_other_starts)
         else:
-            total_progress = compute_result_count(self.args[4], self.args[3])
+            total_progress = compute_result_count(self.args[4], self.args[3], self.allow_other_starts)
 
         result_count = 0
         result_ids = set()
@@ -572,11 +626,12 @@ class GeneratorThread(QThread):
 
     finished = Signal()
 
-    def __init__(self, is_outbreak: bool, is_variable: bool, allow_other_starts: bool, *args) -> None:
+    def __init__(self, is_outbreak: bool, is_variable: bool, allow_other_starts: bool, initial_spawns: int, *args) -> None:
         super().__init__()
         self.is_outbreak = is_outbreak
         self.is_variable = is_variable
         self.allow_other_starts = allow_other_starts
+        self.initial_spawns = initial_spawns
         self.args = args
         self.results = TypedList.empty_list(
             item_type=numba.typeof(
@@ -602,7 +657,7 @@ class GeneratorThread(QThread):
         if self.is_outbreak:
             generate_mass_outbreak(*self.args, self.results)
         elif self.is_variable:
-            generate_variable(self.args[0], self.allow_other_starts, *self.args[1:], self.results)
+            generate_variable(self.args[0], self.allow_other_starts, self.initial_spawns, *self.args[1:], self.results)
         else:
-            generate_standard(self.args[0], self.allow_other_starts, *self.args[1:], self.results)
+            generate_standard(self.args[0], self.allow_other_starts, self.initial_spawns, *self.args[1:], self.results)
         self.finished.emit()


### PR DESCRIPTION
Added the following things:
-Option to allow the generator to also search for paths that start with 1-> or 0-> in case the seed is found through other means that PLA-reverse's seed cracking
-For variable multispawners: added another drop-down box that allows the user to specify the initial spawns, where it got its seed from: 1->1, 2 or 3 as to make it more flexible and less tedious to search for exactly 2 spawns.

For now it's a draft but I did some tests already and it works: only problem is the progress bar which calculation isn't exactly correct so far when choosing the allow_other_starts